### PR TITLE
Add OpenAPI and Swagger Documentation for APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<name>integration</name>
 	<description>Spring Boot integration</description>
 	<properties>
-		<java.version>17</java.version>
+		<java.version>11</java.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -43,6 +43,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.0.2</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-
+springdoc.api-docs.path=/api-docs


### PR DESCRIPTION
This PR introduces the following changes, and closes #1:

- Added the open api dependency
- The Swagger and OpenAPI docs will be available at /api-docs and /swagger-ui/index.html paths
- Downgraded application Java version from 17 to 11